### PR TITLE
Add 32-node Muon microbench fixtures

### DIFF
--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank0.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank0.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 0,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank1.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank1.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 1,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank10.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank10.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 10,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank100.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank100.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 100,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank101.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank101.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 101,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank102.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank102.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 102,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank103.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank103.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 103,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank104.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank104.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 104,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank105.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank105.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 105,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank106.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank106.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 106,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank107.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank107.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 107,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank108.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank108.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 108,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank109.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank109.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 109,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank11.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank11.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 11,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank110.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank110.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 110,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank111.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank111.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 111,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank112.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank112.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 112,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank113.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank113.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 113,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank114.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank114.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 114,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank115.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank115.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 115,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank116.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank116.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 116,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank117.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank117.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 117,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank118.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank118.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 118,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank119.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank119.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 119,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank12.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank12.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 12,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank120.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank120.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 120,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            250,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            956,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            250,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            956,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            250,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            956,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            250,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            956,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            250,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            956,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            250,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            956,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            250,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            956,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            250,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            956,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank121.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank121.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 121,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            250,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            956,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            250,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            956,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            250,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            956,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            250,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            956,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            250,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            956,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            250,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            956,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            250,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            956,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            250,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            956,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank122.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank122.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 122,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank123.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank123.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 123,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank124.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank124.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 124,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank125.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank125.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 125,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank126.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank126.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 126,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1796,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank127.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank127.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 127,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1796,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9216
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank13.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank13.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 13,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank14.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank14.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 14,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            554,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            554,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            554,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            554,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            554,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            554,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            554,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            554,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank15.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank15.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 15,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            554,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            554,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            554,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            554,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            554,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            554,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            554,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            652,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            554,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank16.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank16.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 16,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank17.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank17.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 17,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank18.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank18.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 18,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank19.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank19.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 19,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank2.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank2.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 2,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank20.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank20.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 20,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank21.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank21.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 21,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank22.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank22.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 22,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank23.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank23.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 23,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank24.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank24.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 24,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank25.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank25.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 25,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank26.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank26.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 26,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank27.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank27.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 27,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank28.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank28.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 28,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank29.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank29.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 29,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank3.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank3.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 3,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank30.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank30.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 30,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank31.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank31.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 31,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank32.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank32.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 32,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank33.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank33.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 33,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank34.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank34.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 34,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank35.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank35.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 35,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank36.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank36.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 36,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            36,
+            100
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank37.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank37.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 37,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            37,
+            101
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank38.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank38.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 38,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            38,
+            102
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank39.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank39.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 39,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            39,
+            103
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank4.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank4.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 4,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank40.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank40.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 40,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            40,
+            104
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank41.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank41.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 41,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            41,
+            105
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank42.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank42.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 42,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            42,
+            106
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank43.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank43.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 43,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            43,
+            107
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank44.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank44.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 44,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            44,
+            108
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank45.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank45.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 45,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            45,
+            109
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank46.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank46.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 46,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            46,
+            110
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank47.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank47.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 47,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            47,
+            111
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank48.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank48.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 48,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            48,
+            112
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank49.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank49.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 49,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            49,
+            113
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank5.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank5.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 5,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank50.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank50.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 50,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            50,
+            114
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank51.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank51.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 51,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            51,
+            115
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank52.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank52.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 52,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            52,
+            116
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank53.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank53.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 53,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            53,
+            117
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank54.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank54.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 54,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            54,
+            118
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank55.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank55.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 55,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            340,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            55,
+            119
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            224,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank56.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank56.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 56,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            56,
+            120
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank57.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank57.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 57,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            57,
+            121
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank58.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank58.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 58,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            58,
+            122
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank59.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank59.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 59,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            59,
+            123
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank6.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank6.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 6,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank60.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank60.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 60,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            60,
+            124
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank61.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank61.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 61,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            61,
+            125
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank62.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank62.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 62,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            62,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank63.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank63.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 63,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            288,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            900,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            63,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank64.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank64.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 64,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            64
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank65.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank65.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 65,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            65
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank66.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank66.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 66,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            2,
+            66
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank67.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank67.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 67,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            3,
+            67
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank68.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank68.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 68,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            4,
+            68
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank69.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank69.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 69,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            5,
+            69
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank7.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank7.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 7,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank70.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank70.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 70,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            6,
+            70
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank71.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank71.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 71,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            7,
+            71
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank72.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank72.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 72,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank73.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank73.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 73,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            23,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            200,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank74.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank74.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 74,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            10,
+            74
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank75.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank75.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 75,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            11,
+            75
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank76.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank76.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 76,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            12,
+            76
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank77.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank77.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 77,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            13,
+            77
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank78.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank78.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 78,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            14,
+            78
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank79.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank79.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 79,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            15,
+            79
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank8.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank8.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 8,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            8,
+            72
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank80.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank80.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 80,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            16,
+            80
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank81.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank81.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 81,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            17,
+            81
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank82.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank82.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 82,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            18,
+            82
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank83.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank83.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 83,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            19,
+            83
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank84.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank84.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 84,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            20,
+            84
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank85.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank85.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 85,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            402,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            804,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            21,
+            85
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank86.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank86.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 86,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            22,
+            86
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank87.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank87.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 87,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            23,
+            87
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank88.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank88.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 88,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            24,
+            88
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank89.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank89.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 89,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            25,
+            89
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank9.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank9.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 9,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2048,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            9,
+            73
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank90.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank90.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 90,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            26,
+            90
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank91.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank91.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 91,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            27,
+            91
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank92.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank92.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 92,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            28,
+            92
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank93.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank93.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 93,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            29,
+            93
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            225,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank94.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank94.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 94,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1924,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            30,
+            94
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank95.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank95.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 95,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1924,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            31,
+            95
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            195,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            48,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank96.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank96.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 96,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            32,
+            96
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank97.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank97.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 97,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1206,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            144,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            33,
+            97
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank98.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank98.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 98,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1054,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            152,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            80,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1054,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            152,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1054,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            152,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            80,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1054,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            152,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            80,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1054,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            152,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            80,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1054,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            152,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1054,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            152,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            80,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1054,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            152,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            80,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            80,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            34,
+            98
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            0,
+            2,
+            4,
+            6,
+            8,
+            10,
+            12,
+            14,
+            16,
+            18,
+            20,
+            22,
+            24,
+            26,
+            28,
+            30,
+            32,
+            34,
+            36,
+            38,
+            40,
+            42,
+            44,
+            46,
+            48,
+            50,
+            52,
+            54,
+            56,
+            58,
+            60,
+            62,
+            64,
+            66,
+            68,
+            70,
+            72,
+            74,
+            76,
+            78,
+            80,
+            82,
+            84,
+            86,
+            88,
+            90,
+            92,
+            94,
+            96,
+            98,
+            100,
+            102,
+            104,
+            106,
+            108,
+            110,
+            112,
+            114,
+            116,
+            118,
+            120,
+            122,
+            124,
+            126
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank99.json
+++ b/tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank99.json
@@ -1,0 +1,26895 @@
+{
+  "world_size": 128,
+  "rank": 99,
+  "groups": [
+    {
+      "params": [
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1054,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            152,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            80,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1054,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            152,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1054,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            152,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            80,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1054,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            152,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            80,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1054,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            152,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            80,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1054,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            152,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1054,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            152,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            80,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            1054,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            152,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432,
+            1,
+            4
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            1,
+            4
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            35072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            80,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            64,
+            16384
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128,
+            4096
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            80,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            512,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            9,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            4096,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            5120,
+            2048
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            5120,
+            2048
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            2048,
+            5120
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            1
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            35,
+            99
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            10240,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192,
+            10240
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            360,
+            5120
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=1)"
+          ]
+        },
+        {
+          "global_shape": [
+            131072,
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            2052,
+            8192
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    },
+    {
+      "params": [
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            18432
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            256
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            16384
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32,
+            2
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp",
+            "tp"
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            128
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        },
+        {
+          "global_shape": [
+            8192
+          ],
+          "dtype": "torch.float32",
+          "is_qkv": false,
+          "local_shape": [
+            0
+          ],
+          "mesh_shape": [
+            2,
+            32
+          ],
+          "mesh_dim_names": [
+            "outer_fsdp_dp",
+            "dp_cp"
+          ],
+          "mesh_ranks": [
+            1,
+            3,
+            5,
+            7,
+            9,
+            11,
+            13,
+            15,
+            17,
+            19,
+            21,
+            23,
+            25,
+            27,
+            29,
+            31,
+            33,
+            35,
+            37,
+            39,
+            41,
+            43,
+            45,
+            47,
+            49,
+            51,
+            53,
+            55,
+            57,
+            59,
+            61,
+            63,
+            65,
+            67,
+            69,
+            71,
+            73,
+            75,
+            77,
+            79,
+            81,
+            83,
+            85,
+            87,
+            89,
+            91,
+            93,
+            95,
+            97,
+            99,
+            101,
+            103,
+            105,
+            107,
+            109,
+            111,
+            113,
+            115,
+            117,
+            119,
+            121,
+            123,
+            125,
+            127
+          ],
+          "placements": [
+            "Shard(dim=0)",
+            "Shard(dim=0)"
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/tests/unit_tests/distributed/megatron_fsdp/test_muon.py
+++ b/tests/unit_tests/distributed/megatron_fsdp/test_muon.py
@@ -59,9 +59,17 @@ from tests.unit_tests.distributed.megatron_fsdp.conftest import DistributedSetup
 QKV_SPLIT_SHAPES = (1024, 128, 128)
 
 
-SPEC_DIR = pathlib.Path(__file__).parent / "muon_inputs_fsdp4_tp2"
-EXPECTED_WORLD_SIZE = 8
+# Fixture dirs by WORLD_SIZE — one dump capture per parallelism config.
+_SPEC_DIR_BY_WORLD_SIZE = {
+    8: "muon_inputs_fsdp4_tp2",  # 2-node: (dp_cp=4, tp=2)
+    128: "muon_inputs_outer2_fsdp32_tp2",  # 32-node HSDP: (outer_fsdp_dp=2, dp_cp=32, tp=2)
+}
 WORLD_SIZE = int(os.getenv("WORLD_SIZE", "1"))
+SPEC_DIR = (
+    pathlib.Path(__file__).parent / _SPEC_DIR_BY_WORLD_SIZE[WORLD_SIZE]
+    if WORLD_SIZE in _SPEC_DIR_BY_WORLD_SIZE
+    else None
+)
 
 
 pytestmark = [
@@ -73,9 +81,9 @@ pytestmark = [
         not HAVE_EMERGING_OPTIMIZERS, reason="Muon tests require the emerging-optimizers package"
     ),
     pytest.mark.skipif(
-        WORLD_SIZE != EXPECTED_WORLD_SIZE,
-        reason=f"Dump captured at WORLD_SIZE={EXPECTED_WORLD_SIZE}, "
-        f"got WORLD_SIZE={WORLD_SIZE}",
+        WORLD_SIZE not in _SPEC_DIR_BY_WORLD_SIZE,
+        reason=f"No fixture for WORLD_SIZE={WORLD_SIZE}; "
+        f"supported: {sorted(_SPEC_DIR_BY_WORLD_SIZE)}",
     ),
     pytest.mark.skipif(
         not torch.cuda.is_available(), reason="CUDA is required for the Muon microbenchmark."


### PR DESCRIPTION
## Summary

Captures one optimizer dump from a 32-node / 128-rank training run (HSDP with TP=2, EP=64, outer_fsdp_dp=2, dp_cp=32) via PR [#5307](https://github.com/NVIDIA/Megatron-LM/pull/5307)'s `dump_optimizer_parameters` helper, and switches `test_muon.py` from a single hardcoded `SPEC_DIR` to a `WORLD_SIZE`-indexed lookup so the 8-rank fixture (from PR [#5078](https://github.com/NVIDIA/Megatron-LM/pull/5078)) and the new 128-rank fixture coexist. Launches pick the matching fixture by their own `WORLD_SIZE`; mismatched launches skip.

> **Note on diff size:** ~all of the ~8.5M added lines are the 128 captured-input JSON fixture files (128 × ~67k lines per rank — bigger model, more params per rank than the 8-rank case). Hand-written code is ~15 lines on top of PR #5078.

## What's in this PR

- `tests/unit_tests/distributed/megatron_fsdp/muon_inputs_outer2_fsdp32_tp2/rank{0..127}.json` — **new** — 128 fixture files emitted by `dump_optimizer_parameters` from a real 32-node training step. Each rank records 614 wd-group + 180 no-wd params, with flat `mesh_ranks` (per PR #5307's schema). Per-param meshes seen include `(outer_fsdp_dp=2, dp_cp=32, tp=2)`, `(outer_fsdp_dp=2, dp_cp=32)`, `(outer_fsdp_dp=2, dp_cp=1)`, etc.
- `tests/unit_tests/distributed/megatron_fsdp/test_muon.py` (+13/-5) — replaces the single `SPEC_DIR`/`EXPECTED_WORLD_SIZE` constants with a `_SPEC_DIR_BY_WORLD_SIZE = {8: ..., 128: ...}` lookup. The `pytestmark.skipif` now checks `WORLD_SIZE not in` the dict. No changes to the test bodies — the per-param mesh + collective `_build_mesh_cache` architecture already handles arbitrary mesh layouts (including the 3D `(outer_fsdp_dp, dp_cp, tp)` mesh).

## Dependencies

- PR [#5078](https://github.com/NVIDIA/Megatron-LM/pull/5078): adds `FSDPTensorParallelMuon`, the test framework, and the 8-rank fixture. **This PR is stacked on #5078.**
- PR [#5307](https://github.com/NVIDIA/Megatron-LM/pull/5307): adds `dump_optimizer_parameters` (the helper used to generate the fixtures). The fixture files committed here were produced by that helper.

## How to run

```
torchrun --nproc_per_node=128 --standalone -m pytest \
    tests/unit_tests/distributed/megatron_fsdp/test_muon.py -v -s
```

(Or launch under SLURM with 32 nodes × 4 GPUs.)

## Test plan

- [x] Dump was generated by re-running `hybrid_moe_train_32_nodes.sh` against the head of #5307; all 128 ranks produced consistent fixtures with flat `mesh_ranks`.
- [x] 8-rank tests still pass with the dict-based `SPEC_DIR` lookup (verified after the refactor — same green run as before).
- [x] 128-rank tests pass on gb300 (32 nodes × 4 GPUs, job 2130544). Microbench mean: ~5.07 s/step (rank 0, 5 rounds).
